### PR TITLE
[INC-5312] Add placeholder for image

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

When creating a new product without an image, broken images were showing up in the product catalog. Fixed by adding a fallback image if the item image is not present.

<img width="1170" alt="Screenshot 2022-07-23 at 23 47 19" src="https://user-images.githubusercontent.com/44522063/180625362-ac265097-0ad3-4269-a165-d16920ce7e61.png">

<img width="1170" alt="Screenshot 2022-07-23 at 23 52 25" src="https://user-images.githubusercontent.com/44522063/180625409-32c3f77d-f497-4159-87a5-66bcc1deca41.png">
